### PR TITLE
Implement a two-steps provisioning process for cluster nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.log
 
 env.yaml
+
+kubernetes-playground-base.box

--- a/README.md
+++ b/README.md
@@ -22,14 +22,21 @@ This project is a playground to play with Kubernetes.
 
 ## How to Run
 
-After installing the dependencies, run:
+The provisioning and configuration process has two phases:
 
-1. `vagrant up`
+1. Prepare a base Vagrant box.
+   1. Provision and configure a VM (`vagrant up base-box-builder.k8s-play.local`).
+   1. Export a Vagrant box based on the `vagrant up base-box-builder.k8s-play.local` VM.
+1. Provision and configure the rest of the environment using the base box.
 
-to bootstrap the environment:
+To provision and configure the environment as described, run the following
+commands from the root of the repository:
 
-1. Vagrant will provision master and worker nodes
-1. Ansible will install `docker`, `kubeadm`, `kubelet` and `kubectl` and run configuration scripts to initialize the Kubernetes cluster
+1. Provision and configure the base VM: `vagrant up base-box-builder.k8s-play.local`
+1. Export the base Vagrant box: `vagrant package base-box-builder.k8s-play.local --output kubernetes-playground-base.box`
+1. Destroy the base VM: `vagrant destroy --force base-box-builder.k8s-play.local`
+1. Register the base Vagrant box to make it avaliable to Vagrant: `vagrant box add kubernetes-playground-base.box --name ferrarimarco/kubernetes-playground-node`
+1. Provision and configure the rest of the environment: `vagrant up`
 
 ### Environment-specific configuration
 

--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,1 +1,2 @@
 hosts
+hosts-base

--- a/ansible/playbooks/kubernetes.yml
+++ b/ansible/playbooks/kubernetes.yml
@@ -46,7 +46,7 @@
       shell: "/vagrant/scripts/linux/bootstrap-kubernetes-{{kubernetes_classifier}}.sh {{kubernetes_master_1_ip}} {{kubeadm_token}}"
       args:
         creates: /etc/kubernetes/kubelet.conf
-      when: inventory_hostname != kubernetes_master_1_ip
+      when: "'kubernetes-minions' in group_names"
     - name: Download gluster-kubernetes
       become: yes
       unarchive:

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,13 +1,16 @@
 conf:
+  base_box_builder_mem: 2048
   master_mem: 2048
   minion_mem: 1024
-  ansi_ctrl_mem: 256
+  ansi_ctrl_mem: 1024
   playground_name: k8s-play
+  base_box_builder_name: base-box-builder
   ansi_ctrl_name: ansi-ctrl
   master_name: k8s-master-1
   minion_1_name: k8s-minion-1
   minion_2_name: k8s-minion-2
   minion_3_name: k8s-minion-3
+  kubernetes_nodes_base_box_id: "bento/centos-7.4"
 net:
   network_prefix: "192.168.0."
   network_prefix_ipv6: "fde4:8dba:82e1:"

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -1,3 +1,12 @@
 #!/bin/sh
 
-docker run --rm -v /vagrant/ansible:/etc/ansible -v /vagrant/ansible/playbooks/files/tls:/opt/tls/self_signed --net=host ferrarimarco/open-development-environment-ansible:2.7.12-alpine /bin/sh -c "ansible-galaxy install -r /etc/ansible/requirements.yml && ansible-playbook /etc/ansible/playbooks/kubernetes.yml && ansible-playbook /etc/ansible/playbooks/openssl-self-signed-certificate.yml"
+echo "Ensure the Docker service is enabled and running"
+systemctl enable docker
+systemctl restart docker
+
+docker run --rm \
+    -v /vagrant/ansible:/etc/ansible \
+    -v /vagrant/ansible/playbooks/files/tls:/opt/tls/self_signed \
+    --net=host \
+    ferrarimarco/open-development-environment-ansible:2.7.12-alpine \
+    /bin/sh -c "ansible-galaxy install -r /etc/ansible/requirements.yml && ansible-playbook /etc/ansible/playbooks/kubernetes.yml && ansible-playbook /etc/ansible/playbooks/openssl-self-signed-certificate.yml"

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ! TEMP="$(getopt -o vdm: --long inventory: -n 'install-docker' -- "$@")" ; then echo "Terminating..." >&2 ; exit 1 ; fi
+if ! TEMP="$(getopt -o vdm: --long inventory: -n 'install-kubernetes' -- "$@")" ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$TEMP"
 
 inventory=

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -1,12 +1,28 @@
 #!/bin/sh
 
+if ! TEMP="$(getopt -o vdm: --long inventory: -n 'install-docker' -- "$@")" ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$TEMP"
+
+inventory=
+
+while true; do
+  case "$1" in
+    -u | --inventory ) inventory="$2"; shift 2 ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
 echo "Ensure the Docker service is enabled and running"
 systemctl enable docker
 systemctl restart docker
 
+inventory="/etc/"$inventory
+
+echo "Running Ansible playbooks against $inventory inventory"
 docker run --rm \
     -v /vagrant/ansible:/etc/ansible \
     -v /vagrant/ansible/playbooks/files/tls:/opt/tls/self_signed \
     --net=host \
     ferrarimarco/open-development-environment-ansible:2.7.12-alpine \
-    /bin/sh -c "ansible-galaxy install -r /etc/ansible/requirements.yml && ansible-playbook /etc/ansible/playbooks/kubernetes.yml && ansible-playbook /etc/ansible/playbooks/openssl-self-signed-certificate.yml"
+    /bin/sh -c "ansible-galaxy install -r /etc/ansible/requirements.yml && ansible-playbook -i $inventory /etc/ansible/playbooks/kubernetes.yml && ansible-playbook -i $inventory /etc/ansible/playbooks/openssl-self-signed-certificate.yml"


### PR DESCRIPTION
This PR is an attempt to mitigate #31. The provisioning and configuration process does the following:

1. Provision a single VM to use as a base for the other nodes.
1. Configure the base VM.
1. Export a Vagrant box using the base VM as a base.
1. Provision the cluster nodes using the exported box as a base.
1. Configure the cluster nodes.

Additionally, we now use the same box as a base for all the VMs, including the controller.

Closes #7
Closes #31