### PR TITLE
fix virtualbox host resolver

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -290,6 +290,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
         vb.customize ["modifyvm", :id, "--memory", info[:mem]]
         vb.customize ["modifyvm", :id, "--name", hostname]
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.gui = info[:show_gui]
         vb.name = hostname
       end


### PR DESCRIPTION
We need to force VirtualBox to use the host DNS API to resolve names instead of passing DNS requests to an external DNS server. In this way, the local names stored in the local /etc/hosts file (C:\Windows\System32\drivers\etc\hosts in windows) of the VirtualBox host will be used.

Fixes #46 