### PR TITLE
add net-tests/iperf_ds.yaml

### DIFF
--- a/kubernetes/net-tests/iperf_ds.yaml
+++ b/kubernetes/net-tests/iperf_ds.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: iperf-ds
+  labels:
+    app: iperf-ds
+spec:
+  selector:
+    matchLabels:
+      app: iperf
+  template:
+    metadata:
+      labels:
+        app: iperf
+    spec:
+      containers:
+      - name: iperf-server
+        image: networkstatic/iperf3
+        ports: 
+        - containerPort: 5201
+        args: ["-s"]
+ 

--- a/kubernetes/net-tests/iperf_ds.yaml
+++ b/kubernetes/net-tests/iperf_ds.yaml
@@ -19,4 +19,3 @@ spec:
         ports: 
         - containerPort: 5201
         args: ["-s"]
- 


### PR DESCRIPTION
when the network plugin is installed, we should deploy containers and make experiments...
this PR adds a folder and a .yaml to create an iperf daemonset
kubectl apply -f /vagrant/kubernetes/iperf_ds.yaml