### PR TITLE
add cleanup-k8s-and-cni.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ commands from the root of the repository:
 You can find the default configuration in [`defaults.yaml`](defaults.yaml). If you want to override any default setting, create `env.yaml` and save it in the
 same directory as the `defaults.yaml`. The [`Vagrantfile`](Vagrantfile) will instruct Vagrant to load it.
 
+### Cleaning up
+
+If you want to re-test the initializion of the Kubernetes cluster, you can run
+a specific Vagrant provisioner that doesen't run in during the normal provisioning
+phase, and then execute the normal provisioning again:
+
+1. `vagrant provision --provision-with cleanup`
+1. `vagrant provision`
+
 ### Cloud Native Storage
 
 To deploy GlusterFS, SSH into the master and run the configuration script:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -347,6 +347,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           s.path = "scripts/linux/install-kubernetes.sh"
           s.args = ["--inventory", ansible_inventory_path]
         end
+      else
+        host.vm.provision "cleanup", type: "shell", run: "never" do |s|
+          s.path = "scripts/linux/cleanup-k8s-and-cni.sh"
+        end
       end
     end
   end

--- a/scripts/linux/cleanup-k8s-and-cni.sh
+++ b/scripts/linux/cleanup-k8s-and-cni.sh
@@ -5,10 +5,7 @@
 #can be repeated multiple times
 
 #usage:
-# cleanup-k8s-and-cni.sh PLAYGROUND_NAME
-#example:
-# cleanup-k8s-and-cni.sh k8s-play
-
+# cleanup-k8s-and-cni.sh 
 
 #clean up kubernetes control information and cni settings in all nodes
 
@@ -17,6 +14,8 @@ sudo rm "$HOME/.kube/config"
 sudo rm /root/.kube/config
 sudo rm -rf /etc/cni/net.d
 
+#clean up iptables
+
 sudo iptables -P INPUT ACCEPT
 sudo iptables -P FORWARD ACCEPT
 sudo iptables -P OUTPUT ACCEPT
@@ -24,21 +23,4 @@ sudo iptables -t nat -F
 sudo iptables -t mangle -F
 sudo iptables -F
 sudo iptables -X
-
-PLAYGROUND_NAME="$1"
-#PLAYGROUND_NAME="k8s-p9"
-
-#clean up /etc/hosts
-SCRIPT_NAME="manage-hosts.sh"
-SCRIPT_PATH="/vagrant/scripts/linux"
-
-MASTER_1="k8s-master-1"
-MINION_1="k8s-minion-1"
-MINION_2="k8s-minion-2"
-MINION_3="k8s-minion-3"
-
-$SCRIPT_PATH/$SCRIPT_NAME remove "$MASTER_1.$PLAYGROUND_NAME.local"
-$SCRIPT_PATH/$SCRIPT_NAME remove "$MINION_1.$PLAYGROUND_NAME.local"
-$SCRIPT_PATH/$SCRIPT_NAME remove "$MINION_2.$PLAYGROUND_NAME.local"
-$SCRIPT_PATH/$SCRIPT_NAME remove "$MINION_3.$PLAYGROUND_NAME.local"
 

--- a/scripts/linux/cleanup-k8s-and-cni.sh
+++ b/scripts/linux/cleanup-k8s-and-cni.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+#this script is useful to manually clean up the kubernetes, cni plugin, and
+#networking environments, so that the installation of kubernetes and cni plugin
+#can be repeated multiple times
+
+#usage:
+# cleanup-k8s-and-cni.sh PLAYGROUND_NAME
+#example:
+# cleanup-k8s-and-cni.sh k8s-play
+
+
+#clean up kubernetes control information and cni settings in all nodes
+
+sudo kubeadm reset -f
+sudo rm "$HOME/.kube/config"
+sudo rm /root/.kube/config
+sudo rm -rf /etc/cni/net.d
+
+sudo iptables -P INPUT ACCEPT
+sudo iptables -P FORWARD ACCEPT
+sudo iptables -P OUTPUT ACCEPT
+sudo iptables -t nat -F
+sudo iptables -t mangle -F
+sudo iptables -F
+sudo iptables -X
+
+PLAYGROUND_NAME="$1"
+#PLAYGROUND_NAME="k8s-p9"
+
+#clean up /etc/hosts
+SCRIPT_NAME="manage-hosts.sh"
+SCRIPT_PATH="/vagrant/scripts/linux"
+
+MASTER_1="k8s-master-1"
+MINION_1="k8s-minion-1"
+MINION_2="k8s-minion-2"
+MINION_3="k8s-minion-3"
+
+$SCRIPT_PATH/$SCRIPT_NAME remove "$MASTER_1.$PLAYGROUND_NAME.local"
+$SCRIPT_PATH/$SCRIPT_NAME remove "$MINION_1.$PLAYGROUND_NAME.local"
+$SCRIPT_PATH/$SCRIPT_NAME remove "$MINION_2.$PLAYGROUND_NAME.local"
+$SCRIPT_PATH/$SCRIPT_NAME remove "$MINION_3.$PLAYGROUND_NAME.local"
+


### PR DESCRIPTION
this script is useful to manually clean up the kubernetes, cni plugin, and
networking environments, so that the installation of kubernetes and cni plugin
can be repeated multiple times