### PR TITLE
Persistent ipv6 address

### DIFF
--- a/scripts/linux/configure-ipv6-interface.sh
+++ b/scripts/linux/configure-ipv6-interface.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+echo "making IPv4 forwarding permanent"
+
+fgrep -v net.ipv4.ip_forward /etc/sysctl.conf > /etc/sysctl.conf.mytmp
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf.mytmp
+mv /etc/sysctl.conf.mytmp /etc/sysctl.conf
+
 echo "Configuring the IPv6 interface"
 
 CURRENT_IPV4_ADDRESS="$2"

--- a/scripts/linux/configure-ipv6-interface.sh
+++ b/scripts/linux/configure-ipv6-interface.sh
@@ -2,7 +2,7 @@
 
 echo "making IPv4 forwarding permanent"
 
-fgrep -v net.ipv4.ip_forward /etc/sysctl.conf > /etc/sysctl.conf.mytmp
+grep -Fv net.ipv4.ip_forward /etc/sysctl.conf > /etc/sysctl.conf.mytmp
 echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf.mytmp
 mv /etc/sysctl.conf.mytmp /etc/sysctl.conf
 

--- a/scripts/linux/configure-ipv6-interface.sh
+++ b/scripts/linux/configure-ipv6-interface.sh
@@ -2,8 +2,8 @@
 
 echo "making IPv4 forwarding permanent"
 
-grep -Fv net.ipv4.ip_forward /etc/sysctl.conf > /etc/sysctl.conf.mytmp
-echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf.mytmp
+grep -Fv net.ipv4.ip_forward /etc/sysctl.conf >/etc/sysctl.conf.mytmp
+echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf.mytmp
 mv /etc/sysctl.conf.mytmp /etc/sysctl.conf
 
 echo "Configuring the IPv6 interface"
@@ -18,11 +18,9 @@ echo "Current NetworkManager UUID $UUID assigned to $DEVICE"
 IPV6_ADDRESS="$1"
 IPV6_NETMASK="$3"
 echo "Adding $IPV6_ADDRESS to $DEVICE"
-#ip -6 address add "$IPV6_ADDRESS/$IPV6_NETMASK" dev "$DEVICE"
 nmcli con mod "$UUID" ipv6.address "$IPV6_ADDRESS/$IPV6_NETMASK" ipv6.method manual
 
 echo "Restarting NetworkManager"
 systemctl restart network
 
 echo "Getting all the IP addresses: $(ip -o addr show scope global)"
-

--- a/scripts/linux/configure-ipv6-interface.sh
+++ b/scripts/linux/configure-ipv6-interface.sh
@@ -6,9 +6,17 @@ CURRENT_IPV4_ADDRESS="$2"
 DEVICE="$(ip -o addr show scope global | grep "$CURRENT_IPV4_ADDRESS" | awk '{print $2}')"
 echo "Current IPv4 address $CURRENT_IPV4_ADDRESS assigned to $DEVICE"
 
+UUID="$(nmcli -g UUID,DEVICE con show | grep "$DEVICE" | awk -F ":" '{print $1}')"
+echo "Current NetworkManager UUID $UUID assigned to $DEVICE"
+
 IPV6_ADDRESS="$1"
 IPV6_NETMASK="$3"
 echo "Adding $IPV6_ADDRESS to $DEVICE"
-ip -6 address add "$IPV6_ADDRESS/$IPV6_NETMASK" dev "$DEVICE"
+#ip -6 address add "$IPV6_ADDRESS/$IPV6_NETMASK" dev "$DEVICE"
+nmcli con mod $UUID ipv6.address "$IPV6_ADDRESS/$IPV6_NETMASK" ipv6.method manual
+
+echo "Restarting NetworkManager"
+systemctl restart network
 
 echo "Getting all the IP addresses: $(ip -o addr show scope global)"
+

--- a/scripts/linux/configure-ipv6-interface.sh
+++ b/scripts/linux/configure-ipv6-interface.sh
@@ -19,7 +19,7 @@ IPV6_ADDRESS="$1"
 IPV6_NETMASK="$3"
 echo "Adding $IPV6_ADDRESS to $DEVICE"
 #ip -6 address add "$IPV6_ADDRESS/$IPV6_NETMASK" dev "$DEVICE"
-nmcli con mod $UUID ipv6.address "$IPV6_ADDRESS/$IPV6_NETMASK" ipv6.method manual
+nmcli con mod "$UUID" ipv6.address "$IPV6_ADDRESS/$IPV6_NETMASK" ipv6.method manual
 
 echo "Restarting NetworkManager"
 systemctl restart network


### PR DESCRIPTION
this PR improves configure-ipv6-interface.sh by making the IPv6 address configuration resilient to reboots 

network manager is restarted during the process, losing the IPv4 enable information 

for this reason, /etc/sysctl.conf is edited adding
net.ipv4.ip_forward=1