### PR TITLE
Avoid cluster-specific tasks on the base box, cleanup Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,8 +72,6 @@ master_mem = settings["conf"]["master_mem"]
 minion_mem = settings["conf"]["minion_mem"]
 ansi_ctrl_mem = settings["conf"]["ansi_ctrl_mem"]
 
-additional_disk_size = 10240
-
 playground = {
   base_box_builder_vm_id => {
     :autostart => false,
@@ -97,7 +95,6 @@ playground = {
     :net_auto_config => true,
     :net_type => network_type_static_ip,
     :subnet_mask => subnet_mask,
-    :subnet_mask_ipv6 => subnet_mask_ipv6,
     :show_gui => false,
     :host_vars => {
       "ipv6_address" => kubernetes_master_1_ipv6,
@@ -283,7 +280,7 @@ class VagrantPlugins::ProviderVirtualBox::Action::SetName
       end
     end
 
-    size = additional_disk_size
+    size = 10240
     name = env[:machine].provider_config.name
     disk_file = vm_folder + "/#{name}-disk-2.vmdk"
 
@@ -309,10 +306,6 @@ Vagrant.configure("2") do |config|
         host.vm.network :private_network, auto_config: info[:net_auto_config], :mac => "#{info[:mac_address]}", type: info[:net_type]
       elsif(network_type_static_ip == info[:net_type])
         host.vm.network :private_network, auto_config: info[:net_auto_config], :mac => "#{info[:mac_address]}", ip: "#{info[:ip]}", :netmask => "#{info[:subnet_mask]}"
-
-        if(info.key?(:ipv6))
-          host.vm.network :private_network, auto_config: info[:net_auto_config], :mac => "#{info[:mac_address_ipv6]}", ip: "#{info[:ipv6]}", :netmask => "#{info[:subnet_mask_ipv6]}"
-        end
       end
 
       if info.key?(:alias)

--- a/ansible/playbooks/kubernetes.yml
+++ b/ansible/playbooks/kubernetes.yml
@@ -13,6 +13,7 @@
       register: ip_addr_broadcast
       tags:
         - quick_setup
+      when: "'kubernetes-masters' in group_names or 'kubernetes-minions' in group_names"
     - name: Initialize an IPv6 interface
       become: true
       shell: |
@@ -61,6 +62,7 @@
         owner: root
         src: templates/90-node-ip.conf.j2
       register: configure_kubelet
+      when: "'kubernetes-masters' in group_names or 'kubernetes-minions' in group_names"
     - name: Force systemd to reread configs
       become: true
       systemd:


### PR DESCRIPTION
This PR closes #83 and removes a couple of stale networking configuration bits from the Vagrantfile

Fixes #83 