### PR TITLE
fix apiVersion in some traefik descriptor

### DIFF
--- a/kubernetes/traefik/10-service.yaml
+++ b/kubernetes/traefik/10-service.yaml
@@ -23,7 +23,7 @@ spec:
       name: admin
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: traefik-web-ui

--- a/kubernetes/traefik/20-deployment.yaml
+++ b/kubernetes/traefik/20-deployment.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: traefik-ingress-controller
   namespace: kube-system


### PR DESCRIPTION
this PR fix #91 replacing some deprecated apiVersion in 10-service.yaml and 20-deployment.yaml
as described [here]( https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)