### PR TITLE
Add instructions on how to contribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       install: echo "Overriding the default install, to avoid installing gems from the Gemfile"
       name: "Travis lint"
       stage: linting
-      script: echo "n" | travis lint
+      script: echo "n" | travis lint -x
     - name: "Shellcheck"
       language: shell
       script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish
+to make via GitHub issues with the owners of this repository before making a
+change.
+
+Please note we have a code of conduct, please follow it in all your interactions
+with the project.
+
+## Pull Request Process
+
+1. Update the README.md with details of changes to the interface, this includes
+    new environment variables, exposed ports, useful file locations and
+    container parameters.
+1. If you are releasing a new version, create a Git tag representing the new
+    version. The versioning scheme we use is [SemVer](http://semver.org/).
+1. You may merge the Pull Request in once you have the sign-off of another
+    developer, or if you do not have permission to do that, you may request the
+    the reviewer to merge it for you.
+1. Ensure you maintain a linear history before merging your PR. This is enforced
+    with the "Squash and merge" mode to be the only one available.
+1. Ensure your contributions don't break the build. The continuous integration
+    (CI) process checks if your code meets a set of rules by linting your code
+    and checking the formatting.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ with the project.
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
 
 ### Our Standards
 
@@ -83,8 +83,9 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -92,8 +93,9 @@ members of the project's leadership.
 
 ### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -176,9 +176,12 @@ controllers.
 
 ## Development and testing
 
-To bootstrap a development environment, you need to install the
-runtime dependencies listed above, plus the development environment
-dependencies.
+The test suite is executed automatically by Travis CI on each commit, according
+to the configuration (see [.travis.yml](.travis.yml)).
+
+You can also run the same test suite locally. To bootstrap a development
+environment, you need to install the runtime dependencies listed above, plus the
+development environment dependencies.
 
 ### Running the tests
 
@@ -214,8 +217,8 @@ We currently check the following file types, and enforce the following rules:
 
 #### Compliance test suite
 
-The test suite checks the whole environment for compliance using a verifier (
-[InSpec](https://www.inspec.io/) in this case).
+The test suite checks the whole environment for compliance using a verifier
+([InSpec](https://www.inspec.io/) in this case).
 
 ##### Compliance test suites dependencies
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ The codebase is checked with linters and against common formatting rules.
 
 We currently check the following file types, and enforce the following rules:
 
-| File type                    | Formatting rules                   | Linters and validators |
-|------------------------------|------------------------------------|---------------|
+| File type      | Formatting rules | Linters and validators |
+|----------------|------------------|------------------------|
 | Travis CI configuration file | See [.editorconfig](.editorconfig) | [travis lint](https://github.com/travis-ci/travis.rb#lint) |
 | Shell scripts                | See [.editorconfig](.editorconfig), [shfmt](https://github.com/mvdan/sh) | [Shellcheck](https://github.com/koalaman/shellcheck) |
 | All YAML files               | See [.editorconfig](.editorconfig) | [YAMLlint (strict mode)](https://github.com/adrienverge/yamllint) |

--- a/README.md
+++ b/README.md
@@ -214,3 +214,8 @@ manage the lifecycle of the test instances.
     1. Install bundler: `gem install bundler`
     1. Install required gems: `bundle install`
 1. Run the tests with Test-Kitchen: `kitchen test`
+
+## Contributing
+
+Contributions to this project are welcome! See the instructions in
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ This project is a playground to play with Kubernetes.
     1. QUEMU >= 2.22.1
     1. [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt)
 
-## Test environment
-
-1. Bundler 1.13.0+
-1. Ruby 2.4.0+
-1. See [Gemfile](Gemfile)
-1. See [requirements.txt](requirements.txt)
-1. See [package.json](package.json)
-
 ## How to Run
 
 The provisioning and configuration process has two phases:
@@ -106,21 +98,6 @@ To deploy GlusterFS, SSH into the master and run the configuration script:
 
 1. `vagrant ssh kubernetes-master-1.kubernetes-playground.local`
 1. `sudo /vagrant/scripts/linux/bootstrap-glusterfs.sh`
-
-### Running the tests
-
-The test suite checks the whole environment for compliance using a verifier (
-[InSpec](https://www.inspec.io/) in this case).
-
-You can run the test suite manually. [Test-Kitchen](https://kitchen.ci/) will
-manage the lifecycle of the test instances.
-
-1. Install the dependencies:
-    1. `gem install bundler`
-    1. `bundle install`
-1. Run the tests with Test-Kitchen: `kitchen test`
-
-The CI builds run additional checks and linters. See [.travis.yml](.travis.yml).
 
 ### Ingress Controller
 
@@ -196,3 +173,44 @@ Note that the contents of those file will be overidden on each run.
 
 We generate a self-signed wildcard certificate to use for all the ingress
 controllers.
+
+## Development and testing
+
+To bootstrap a development environment, you need to install the
+runtime dependencies listed above, plus the development environment
+dependencies.
+
+### Running the tests
+
+This section explains how to run linters and the compliance test suites.
+
+#### Linters and formatters
+
+The codebase is checked with linters and against common formatting rules.
+
+##### Linters and formatters dependencies
+
+1. Python 3, with pip.
+1. NodeJS, with npm.
+1. See [requirements.txt](requirements.txt).
+1. See [package.json](package.json).
+
+#### Compliance test suite
+
+The test suite checks the whole environment for compliance using a verifier (
+[InSpec](https://www.inspec.io/) in this case).
+
+##### Compliance test suites dependencies
+
+1. Ruby 2.6.0+
+1. Bundler 1.13.0+
+
+##### How to run the compliance test suites
+
+You can run the test suite manually. [Test-Kitchen](https://kitchen.ci/) will
+manage the lifecycle of the test instances.
+
+1. Install the dependencies (you need to have a working Ruby environment):
+    1. Install bundler: `gem install bundler`
+    1. Install required gems: `bundle install`
+1. Run the tests with Test-Kitchen: `kitchen test`

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ dependencies.
 
 ### Running the tests
 
-This section explains how to run linters and the compliance test suites.
+This section explains how to run linters and the compliance test suites. The
+same linters and test suites run automatically on each commit.
 
 #### Linters and formatters
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ The codebase is checked with linters and against common formatting rules.
 1. See [requirements.txt](requirements.txt).
 1. See [package.json](package.json).
 
+##### Linting and formatting rules
+
+We currently check the following file types, and enforce the following rules:
+
+| File type                    | Formatting rules                   | Linters and validators |
+|------------------------------|------------------------------------|---------------|
+| Travis CI configuration file | See [.editorconfig](.editorconfig) | [travis lint](https://github.com/travis-ci/travis.rb#lint) |
+| Shell scripts                | See [.editorconfig](.editorconfig), [shfmt](https://github.com/mvdan/sh) | [Shellcheck](https://github.com/koalaman/shellcheck) |
+| All YAML files               | See [.editorconfig](.editorconfig) | [YAMLlint (strict mode)](https://github.com/adrienverge/yamllint) |
+| Markdown files               | See [.editorconfig](.editorconfig) | [markdownlint](https://github.com/DavidAnson/markdownlint) |
+| Vagrantfile                  | See [.editorconfig](.editorconfig) | [vagrant validate](https://www.vagrantup.com/docs/cli/validate.html) |
+| Kubernetes descriptors       | See [.editorconfig](.editorconfig) | [kubeval](https://github.com/instrumenta/kubeval) |
+| Ansible playbooks and roles  | See [.editorconfig](.editorconfig) | [ansible-lint](https://docs.ansible.com/ansible-lint/) |
+| Dockerfiles                  | See [.editorconfig](.editorconfig) | [hadolint](https://github.com/hadolint/hadolint) |
+| All text files               | See [.editorconfig](.editorconfig) | N/A |
+
 #### Compliance test suite
 
 The test suite checks the whole environment for compliance using a verifier (


### PR DESCRIPTION
This PR add instructions describing how to run the test suites in the README.

Additionally, I wrote contribution guidelines.

Note that I omitted instructions on how to run linters/checks we do in CI, because I don't want to spend effort before #123. After that PR is merged, updating the README will be a lot easier.

PS: piggybacking a small change in .travis.yml: break the build on warning (not just errors) when linting .travis.yml.

Closes: #89