### PR TITLE
Remove the Ansible controller. Provision from the last worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,17 @@ This project is a playground to play with Kubernetes.
 
 ## Components
 
-1. 1x Kubernetes Master VM
-1. 3x Kubernetes Minions VMs
+1. 1x Kubernetes Master VM.
+1. 3x Kubernetes Minions VMs.
 1. "Controller": a Docker container where we run an Ansible instance to
-   configure the whole environment (the Docker container runs in a
-   separate VM)
+   configure the whole environment.
 1. A hyper-converged, cloud native storage cluster managed with
-   [GlusterFS](https://github.com/gluster/gluster-kubernetes) and [Heketi](https://github.com/heketi/heketi)
-1. A monitoring solution based on [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/)
+   [GlusterFS](https://github.com/gluster/gluster-kubernetes) and [Heketi](https://github.com/heketi/heketi).
+1. A monitoring solution based on [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/).
 1. [Traefik](https://traefik.io/)
    [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-   to map requests to services
-1. A [Docker Registry](https://docs.docker.com/registry/)
+   to map requests to services.
+1. A [Docker Registry](https://docs.docker.com/registry/).
 
 ## Dependencies
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,19 +62,21 @@ vagrant_provider = settings["conf"]["vagrant_provider"]
 # Vagrant boxes
 vagrant_x64_kubernetes_nodes_base_box_id = settings["conf"]["kubernetes_nodes_base_box_id"][vagrant_provider]
 vagrant_x64_kubernetes_nodes_box_id = "ferrarimarco/kubernetes-playground-node"
-vagrant_x64_controller_box_id = vagrant_x64_kubernetes_nodes_box_id
 
 # VM Names
 base_box_builder_vm_name = settings["conf"]["base_box_builder_name"]
-ansible_controller_vm_name = settings["conf"]["ansi_ctrl_name"]
 kubernetes_master_1_vm_name = settings["conf"]["master_name"]
 kubernetes_minion_1_vm_name = settings["conf"]["minion_1_name"]
 kubernetes_minion_2_vm_name = settings["conf"]["minion_2_name"]
 kubernetes_minion_3_vm_name = settings["conf"]["minion_3_name"]
 
+# Defines where to run the Ansible container during the provisioning phase.
+# This must be the last machine to be created, because the other ones have to be
+# available before attempting any provisioning.
+ansible_controller_vm_name = kubernetes_minion_3_vm_name
+
 # VM IDs
 base_box_builder_vm_id = base_box_builder_vm_name + domain
-ansible_controller_vm_id = ansible_controller_vm_name + domain
 kubernetes_master_1_vm_id = kubernetes_master_1_vm_name + domain
 kubernetes_minion_1_vm_id = kubernetes_minion_1_vm_name + domain
 kubernetes_minion_2_vm_id = kubernetes_minion_2_vm_name + domain
@@ -84,7 +86,6 @@ kubernetes_minion_3_vm_id = kubernetes_minion_3_vm_name + domain
 base_box_builder_mem = settings["conf"]["base_box_builder_mem"]
 master_mem = settings["conf"]["master_mem"]
 minion_mem = settings["conf"]["minion_mem"]
-ansi_ctrl_mem = settings["conf"]["ansi_ctrl_mem"]
 
 playground = {
   base_box_builder_vm_id => {
@@ -159,19 +160,7 @@ playground = {
       "ipv6_address" => kubernetes_minion_3_ipv6,
       "assigned_hostname" => kubernetes_minion_3_vm_id
     }
-  },
-  ansible_controller_vm_id => {
-    :autostart => true,
-    :box => vagrant_x64_controller_box_id,
-    :cpus => 1,
-    :mac_address => "0800271F9D01",
-    :mem => ansi_ctrl_mem,
-    :ip => network_prefix + "9",
-    :net_auto_config => true,
-    :net_type => network_type_static_ip,
-    :subnet_mask => subnet_mask,
-    :show_gui => false
-  },
+  }
 }
 
 # Generate an inventory file

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -4,10 +4,8 @@ conf:
   base_box_builder_mem: 2048
   master_mem: 2048
   minion_mem: 1024
-  ansi_ctrl_mem: 1024
   playground_name: k8s-play
   base_box_builder_name: base-box-builder
-  ansi_ctrl_name: ansi-ctrl
   master_name: k8s-master-1
   minion_1_name: k8s-minion-1
   minion_2_name: k8s-minion-2


### PR DESCRIPTION
This PR removes the controller machine (that we used to run Ansible, and provision the other machines). With this change, we run Ansible from the last machine to be brought up: the last worker node.

We might need to refine this strategy when dealing with #34.

Closes #79 