### PR TITLE
Don't install packages with bundler while linting .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jobs:
   fast_finish: true
   include:
     - before_install: gem install travis --no-document
+      install: echo "Overriding the default install, to avoid installing gems from the Gemfile"
       name: "Travis lint"
       stage: linting
       script: echo "n" | travis lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Playground
 
-[![Build Status Master Branch](https://travis-ci.org/ferrarimarco/kubernetes-playground.svg?branch=master)](https://travis-ci.org/ferrarimarco/kubernetes-playground)
+[![Build Status Master Branch](https://travis-ci.com/ferrarimarco/kubernetes-playground.svg?branch=master)](https://travis-ci.com/ferrarimarco/kubernetes-playground)
 
 This project is a playground to play with Kubernetes.
 


### PR DESCRIPTION
This reduces the time needed for the Travis configuration file from 1 minute to about 30 seconds.