### PR TITLE
Don't spawn a subshell when checking if /vagrant is mounted

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -433,8 +433,8 @@ Vagrant.configure("2") do |config|
         end
         $mountNfsShare = ''
         if(vagrant_provider == 'virtualbox')
-            set -e
             $mountNfsShare = <<-'SCRIPT'
+            set -e
             if ! mount | grep -qs /vagrant ; then
                 # From now on, we want the script to fail if we have problems mounting the shares
                 mount -t vboxsf vagrant /vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -435,12 +435,16 @@ Vagrant.configure("2") do |config|
         if(vagrant_provider == 'virtualbox')
             $mountNfsShare = <<-'SCRIPT'
             if ! mount | grep -qs /vagrant ; then
+                # From now on, we want the script to fail if we have problems mounting the shares
+                set -e
                 mount -t vboxsf vagrant /vagrant/
             fi
             SCRIPT
         elsif(vagrant_provider == 'libvirt')
             $mountNfsShare = <<-'SCRIPT'
             if ! mount | grep -qs /vagrant ; then
+                # From now on, we want the script to fail if we have problems mounting the shares
+                set -e
                 mount -t nfs -o 'vers=3' $libvirt_management_host_address:$vagrant_root /vagrant
             fi
             SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -433,18 +433,18 @@ Vagrant.configure("2") do |config|
         end
         $mountNfsShare = ''
         if(vagrant_provider == 'virtualbox')
+            set -e
             $mountNfsShare = <<-'SCRIPT'
             if ! mount | grep -qs /vagrant ; then
                 # From now on, we want the script to fail if we have problems mounting the shares
-                set -e
                 mount -t vboxsf vagrant /vagrant/
             fi
             SCRIPT
         elsif(vagrant_provider == 'libvirt')
             $mountNfsShare = <<-'SCRIPT'
+            set -e
             if ! mount | grep -qs /vagrant ; then
                 # From now on, we want the script to fail if we have problems mounting the shares
-                set -e
                 mount -t nfs -o 'vers=3' $libvirt_management_host_address:$vagrant_root /vagrant
             fi
             SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -434,20 +434,20 @@ Vagrant.configure("2") do |config|
         $mountNfsShare = ''
         if(vagrant_provider == 'virtualbox')
             $mountNfsShare = <<-'SCRIPT'
-            if ! "$(mount | grep /vagrant)" ; then
+            if ! mount | grep -qs /vagrant ; then
                 mount -t vboxsf vagrant /vagrant/
             fi
             SCRIPT
         elsif(vagrant_provider == 'libvirt')
             $mountNfsShare = <<-'SCRIPT'
-            if ! "$(mount | grep /vagrant)" ; then
+            if ! mount | grep -qs /vagrant ; then
                 mount -t nfs -o 'vers=3' $libvirt_management_host_address:$vagrant_root /vagrant
             fi
             SCRIPT
+            $mountNfsShare.gsub!("$libvirt_management_host_address", libvirt_management_host_address)
+            $mountNfsShare.gsub!("$vagrant_root", vagrant_root)
         end
-        $mountNfsShare.gsub!("$libvirt_management_host_address", libvirt_management_host_address)
-        $mountNfsShare.gsub!("$vagrant_root", vagrant_root)
-        host.vm.provision "mount-shared", type:"shell", run: "never", inline: $mountNfsShare
+        host.vm.provision "mount-shared", type: "shell", run: "never", inline: $mountNfsShare
       end
     end
   end


### PR DESCRIPTION
This PR fixes an issue that occurs when checking if we have to mount `/vagrant` (see the `mount-shared`) provisioner. It also mutes `grep` output because we're interested in its return code only.

To summarize:

1. No need to run the check in a subshell. If the directory is not mounted, this results in a syntax error.
1. Mute grep output.
1. Substitute libvirt variables only when necessary, so only when that provider is selected.