### PR TITLE
Upgrade vagrant to 2.2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
   global:
-    - VAGRANT_VERSION="2.2.6"
+    - VAGRANT_VERSION="2.2.7"
 jobs:
   fast_finish: true
   include:


### PR DESCRIPTION
This PR upgrades the Vagrant version we use during our CI builds to `2.2.7`. 

Close #133 