### PR TITLE
Dynamically load environment vars from the CI environment and require Vagrant version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -101,7 +101,6 @@ end
 allowed_cni_plugins=["weavenet","calico","flannel","no-cni-plugin"]
 if not allowed_cni_plugins.include? settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"]
   @ui.error 'kubernetes_network_plugin is not valid in defaults.yaml or env.yaml, allowed values are:'
-  #puts "kubernetes_network_plugin is not valid in defaults.yaml or env.yaml, allowed values are:"
   allowed_cni_plugins.each {|valid| @ui.error valid }
   exit(1)
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,12 @@ if travis_global_environment_variables.kind_of?(Array)
     travis_global_environment_variables = travis_global_environment_variables_hash
 end
 
+# Require the minimum Vagrant version we currently support
+required_vagrant_version = travis_global_environment_variables['VAGRANT_VERSION']
+vagrant_version_constraint = ">= #{required_vagrant_version}"
+Vagrant.require_version vagrant_version_constraint
+@ui.info "The current Vagrant version satisfies the constraints: #{vagrant_version_constraint}"
+
 # Proc settings merger
 settings_merger = proc {
     |key, v_default, v_env|


### PR DESCRIPTION
This PR implements support for:

1. Dynamically loading variables from the Travis CI configuration file ([.travis.yml](.travis.yml)).
1. Require a minimum Vagrant version. The version we require is the same we define for our CI builds.

Close #128 