### PR TITLE
get interface name dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,14 @@ For debbugging and development purpose, you can run a Vagrant provisioner called
 ```shell
 vagrant provision --provision-with ansible-debug
 ```
+
 With this provisioner, ansible will execute only the tasks tagged as follows:
 
 ```yaml
   tags:
     - ansible_debug
 ```
+
 An example task tagged with `ansible_debug` is included in [`ansible\kubernetes.yml`](ansible\kubernetes.yml)
 
 ### Automatic Ansible Inventory Creation

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ development environment dependencies.
 
 Ansible output is saved in the `/vagrant/ansible_output.txt`.
 
-For debbugging and development purpose, you can run a Vagrant provisioner called
+For debbugging and development purposes, you can run a Vagrant provisioner called
 `ansible-debug` as follows:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -210,13 +210,16 @@ development environment dependencies.
 
 ### Debugging ansible operations
 
-Ansible output is saved in the `/vagrant/ansible_output.txt`. It is possible to
-execute the a provisioner in Vagrant called `ansible-debug`:
+Ansible output is saved in the `/vagrant/ansible_output.txt`.
+
+For debbugging and development purpose, you can run a Vagrant provisioner called
+`ansible-debug` as follows:
 
         ```shell
         vagrant provision --provision-with ansible-debug
         ```
 With this provisioner, ansible will execute only the tasks tagged as follows:
+        
         ```yaml
           tags:
             - ansible_debug

--- a/README.md
+++ b/README.md
@@ -215,15 +215,15 @@ Ansible output is saved in the `/vagrant/ansible_output.txt`.
 For debbugging and development purpose, you can run a Vagrant provisioner called
 `ansible-debug` as follows:
 
-        ```shell
-        vagrant provision --provision-with ansible-debug
-        ```
+```shell
+vagrant provision --provision-with ansible-debug
+```
 With this provisioner, ansible will execute only the tasks tagged as follows:
-        
-        ```yaml
-          tags:
-            - ansible_debug
-        ```
+
+```yaml
+  tags:
+    - ansible_debug
+```
 An example task tagged with `ansible_debug` is included in [`ansible\kubernetes.yml`](ansible\kubernetes.yml)
 
 ### Automatic Ansible Inventory Creation

--- a/README.md
+++ b/README.md
@@ -208,9 +208,20 @@ You can also run the same test suite locally. To bootstrap a development
 environment, you need to install the runtime dependencies listed above, plus the
 development environment dependencies.
 
-### Debug output
+### Debugging ansible operations
 
-Ansible output is saved in the `/vagrant/ansible_output.txt`.
+Ansible output is saved in the `/vagrant/ansible_output.txt`. It is possible to
+execute the a provisioner in Vagrant called `ansible-debug`:
+
+        ```shell
+        vagrant provision --provision-with ansible-debug
+        ```
+With this provisioner, ansible will execute only the tasks tagged as follows:
+        ```yaml
+          tags:
+            - ansible_debug
+        ```
+An example task tagged with `ansible_debug` is included in [`ansible\kubernetes.yml`](ansible\kubernetes.yml)
 
 ### Automatic Ansible Inventory Creation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,8 +59,6 @@ kubernetes_minion_1_ipv6 = network_prefix_ipv6 + settings["net"]["minion_1_ipv6_
 kubernetes_minion_2_ipv6 = network_prefix_ipv6 + settings["net"]["minion_2_ipv6_part"]
 kubernetes_minion_3_ipv6 = network_prefix_ipv6 + settings["net"]["minion_3_ipv6_part"]
 
-if_name_for_flannel = settings["net"]["if_name_for_flannel"]
-
 playground_name = settings["conf"]["playground_name"]
 domain = "." + playground_name + ".local"
 
@@ -257,7 +255,6 @@ default_group_vars = {
   "playground_name" => "#{playground_name}",
   "cluster_ip_cidr"  => "#{cluster_ip_cidr}",
   "service_ip_cidr"  => "#{service_ip_cidr}",
-  "if_name_for_flannel"  => "#{if_name_for_flannel}",
 }
 custom_all_group_vars = settings["ansible"]["group_vars"]["all"]
 if !custom_all_group_vars.nil?

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,6 +97,11 @@ if File.exist?(env_specific_config_path)
   end
 end
 
+# Display the main current configuration parameters
+@ui.info "Welcome to Kubernetes playground !"
+@ui.info "Vagrant provider : " + settings["conf"]["vagrant_provider"]
+@ui.info "Networking plugin : " + settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"]
+
 # Check that an allowed networking plugin is provided
 allowed_cni_plugins=["weavenet","calico","flannel","no-cni-plugin"]
 if not allowed_cni_plugins.include? settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"]
@@ -515,6 +520,12 @@ Vagrant.configure("2") do |config|
             s.path = "scripts/linux/install-kubernetes.sh"
             s.args = ["--inventory", ansible_inventory_path, "--additional-ansible-arguments", additional_ansible_arguments, "--quick-setup" ]
           end
+
+          host.vm.provision "ansible-debug", type: "shell", run: "never" do |s|
+            s.path = "scripts/linux/install-kubernetes.sh"
+            s.args = ["--inventory", ansible_inventory_path, "--additional-ansible-arguments", additional_ansible_arguments, "--ansible-debug" ]
+          end
+
         end
         host.vm.provision "cleanup", type: "shell", run: "never" do |s|
           s.path = "scripts/linux/cleanup-k8s-and-cni.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,7 +98,7 @@ if File.exist?(env_specific_config_path)
 end
 
 # Display the main current configuration parameters
-@ui.info "Welcome to Kubernetes playground !"
+@ui.info "Welcome to Kubernetes playground!"
 @ui.info "Vagrant provider : " + settings["conf"]["vagrant_provider"]
 @ui.info "Networking plugin : " + settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"]
 

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -9,12 +9,26 @@
       listen:
         - systemd_read_configs
   post_tasks:
+    - name: ansible_debug
+        This task is executed by vagrant provision --provision-with ansible-debug
+        this task is only an example, it can be replace by your own debug task
+        or other tasks with ansible_debug tag can be created
+      become: true
+      changed_when: false
+      shell: |
+        set -e ; \
+        echo $0 ; \
+        whoami ; \
+        echo $PATH
+      register: ansible_debug_output
+      tags:
+        - ansible_debug
     - name: >-
         Get IP address corresponding to the interface with the specified
         broadcast address
       changed_when: false
       shell: |
-        set -o pipefail; \
+        set -e -o pipefail; \
         /usr/sbin/ip addr \
         | grep {{ broadcast_address }} \
         | awk -F'[ /]+' '{print $3}'
@@ -25,6 +39,7 @@
     - name: Initialize an IPv6 interface
       become: true
       shell: |
+        set -e ; \
         /vagrant/scripts/linux/configure-ipv6-interface.sh \
         {{ ipv6_address }} \
         {{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }} \
@@ -116,10 +131,11 @@
       tags:
         - quick_setup
     - name: Get interface name for data interface
+      become: true
       shell: |
-        set -o pipefail; \
+        set -e -o pipefail ; \
         NODE_IP_V4={{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }} ; \
-        /usr/sbin/ip -o addr show scope global | grep $NODE_IP_V4 | awk '{print $2}'
+        ip -o addr show scope global | grep $NODE_IP_V4 | awk '{print $2}'
       register: node_ip_address
       when: inventory_hostname == kubernetes_master_1_ip
       tags:
@@ -146,6 +162,7 @@
     - name: Initialize Kubernetes cluster (master)
       become: true
       shell: |
+        set -e ; \
         /vagrant/scripts/linux/bootstrap-kubernetes-{{ kubernetes_classifier }}.sh \
         /tmp/kubeadm-config.yaml \
         {{ kubernetes_network_plugin }}

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -10,8 +10,6 @@
         - systemd_read_configs
   post_tasks:
     - name: ansible_debug_example_1
-        To execute this task, call
-        vagrant provision --provision-with ansible-debug
         This task is only an example, it can be replaced by your own debug task
         or other tasks with ansible_debug tag can be created
       become: true

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -124,7 +124,7 @@
       tags:
         - quick_setup
     - name: Define if_name_for_flannel
-      set_fact: 
+      set_fact:
         if_name_for_flannel: "{{ node_ip_address.stdout }}"
       when: inventory_hostname == kubernetes_master_1_ip
       tags:

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -10,7 +10,7 @@
         - systemd_read_configs
   post_tasks:
     - name: ansible_debug_example_1
-        To execute this task, call 
+        To execute this task, call
         vagrant provision --provision-with ansible-debug
         This task is only an example, it can be replaced by your own debug task
         or other tasks with ansible_debug tag can be created

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -115,6 +115,20 @@
       when: inventory_hostname == kubernetes_master_1_ip
       tags:
         - quick_setup
+    - name: Get interface name for data interface
+      shell: |
+        NODE_IP_V4={{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }} ; \
+        /usr/sbin/ip -o addr show scope global | grep $NODE_IP_V4 | awk '{print $2}'
+      register: node_ip_address
+      when: inventory_hostname == kubernetes_master_1_ip
+      tags:
+        - quick_setup
+    - name: Define if_name_for_flannel
+      set_fact: 
+        if_name_for_flannel: "{{ node_ip_address.stdout }}"
+      when: inventory_hostname == kubernetes_master_1_ip
+      tags:
+        - quick_setup
     - name: Generate Flannel configuration file
       become: true
       template:

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -9,9 +9,10 @@
       listen:
         - systemd_read_configs
   post_tasks:
-    - name: ansible_debug
-        This task is executed by vagrant provision --provision-with ansible-debug
-        this task is only an example, it can be replace by your own debug task
+    - name: ansible_debug_example_1
+        To execute this task, call 
+        vagrant provision --provision-with ansible-debug
+        This task is only an example, it can be replaced by your own debug task
         or other tasks with ansible_debug tag can be created
       become: true
       changed_when: false
@@ -21,6 +22,14 @@
         whoami ; \
         echo $PATH
       register: ansible_debug_output
+      tags:
+        - ansible_debug
+    - name: ansible_debug_example_2
+        This task is only an example (see ansible_debug_example_1)
+      become: true
+      changed_when: false
+      debug:
+        var: ansible_debug_output
       tags:
         - ansible_debug
     - name: >-

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -117,6 +117,7 @@
         - quick_setup
     - name: Get interface name for data interface
       shell: |
+        set -o pipefail; \
         NODE_IP_V4={{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }} ; \
         /usr/sbin/ip -o addr show scope global | grep $NODE_IP_V4 | awk '{print $2}'
       register: node_ip_address

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -23,7 +23,6 @@ net:
   minion_1_ipv6_part: "c41e::"
   minion_2_ipv6_part: "c41f::"
   minion_3_ipv6_part: "c420::"
-  if_name_for_flannel: enp0s8
   libvirt_management_network_address: "192.168.121.0/24"
 pod_network:
   cluster_ip_cidr: "10.244.0.0/16"

--- a/scripts/linux/enable-ssh-password-authentication.sh
+++ b/scripts/linux/enable-ssh-password-authentication.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Stop the execution on errors.
 set -e

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-if ! TEMP="$(getopt -o a:i:q --long additional-ansible-arguments:,inventory:,quick-setup -n 'install-kubernetes' -- "$@")"; then
+if ! TEMP="$(getopt -o a:i:q:m --long additional-ansible-arguments:,inventory:,quick-setup,ansible-debug \
+    -n 'install-kubernetes' -- "$@")"; then
     echo "Terminating..." >&2
     exit 1
 fi
@@ -25,6 +26,11 @@ while true; do
         shift
         break
         ;;
+    -m | --ansible-debug)
+        ansible_debug=enabled
+        shift
+        break
+        ;;
     --)
         shift
         break
@@ -35,6 +41,10 @@ done
 
 if [ "$quick_setup" = "enabled" ]; then
     additional_ansible_arguments="$additional_ansible_arguments --tags quick_setup"
+fi
+
+if [ "$ansible_debug" = "enabled" ]; then
+    additional_ansible_arguments="$additional_ansible_arguments --tags ansible_debug"
 fi
 
 echo "Ensure the Docker service is enabled and running"


### PR DESCRIPTION
removed if_name_for_flannel from defaults.yaml
(obviously flannel was not working in the libvirt testbed because the interface was different... and we needed to change it manually in env.yaml)
now the variable if_name_for_flannel is set by ansible in kubernetes.yaml, by executing a shell script on the node
note that the ip command is not working in this shell script, I have replaced with 
/usr/sbin/ip which is working on both:
    virtualbox: "bento/centos-7.4"
    libvirt: "centos/7"
we should investigate why /usr/sbin is not in the path of the shell launched by ansible, while it is ok when ansible executes configure-ipv6-interface.sh