### PR TITLE
Move the sshd configuration script out of the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -473,16 +473,10 @@ Vagrant.configure("2") do |config|
 
         config.ssh.insert_key = false
 
-        if(vagrant_provider == 'libvirt')
-          $enableSshPasswordAuthentication = <<-'SCRIPT'
-          grep -q "^PasswordAuthentication" /etc/ssh/sshd_config && \
-          sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config || \
-          sed -i -e "\$aPasswordAuthentication yes" /etc/ssh/sshd_config;
-          service sshd restart
-          SCRIPT
-
-          host.vm.provision "shell", inline: $enableSshPasswordAuthentication
-        end
+        # Ensure password authentication is enabled.
+        # We might have to resort to a more secure solution in the future, but
+        # for now it's enough.
+        host.vm.provision "shell", path: "scripts/linux/enable-ssh-password-authentication.sh"
 
         host.vm.provision "shell", path: "scripts/linux/check-kubeadm-requirements.sh"
         host.vm.provision "shell" do |s|

--- a/scripts/linux/enable-ssh-password-authentication.sh
+++ b/scripts/linux/enable-ssh-password-authentication.sh
@@ -5,19 +5,19 @@ set -e
 
 SSH_CONFIG_FILE_PATH=/etc/ssh/sshd_config
 if [ -f "$SSH_CONFIG_FILE_PATH" ]; then
-    echo "Enabling password authentication for SSH connections."
-    SSHD_CONFIG_UPDATED=0
+    echo "Checking if password authentication is enabled for SSH connections in: $SSH_CONFIG_FILE_PATH"
+    SSHD_CONFIG_UPDATED="false"
     if grep -q "^PasswordAuthentication no" "$SSH_CONFIG_FILE_PATH"; then
         echo "Password authentication for SSH connections is disabled. Enabling it..."
         sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" "$SSH_CONFIG_FILE_PATH"
-        SSHD_CONFIG_UPDATED=1
-    elif ! grep -q "^PasswordAuthentication"; then
-        echo "Enabling password authentication for SSH connections..."
+        SSHD_CONFIG_UPDATED="true"
+    elif ! grep -q "^PasswordAuthentication" "$SSH_CONFIG_FILE_PATH"; then
+        echo "Password authentication was not configured. Enabling password authentication for SSH connections..."
         sed -i -e "\$aPasswordAuthentication yes" "$SSH_CONFIG_FILE_PATH"
-        SSHD_CONFIG_UPDATED=1
+        SSHD_CONFIG_UPDATED="true"
     fi
 
-    if [ "$SSHD_CONFIG_UPDATED" = 1 ]; then
+    if [ "$SSHD_CONFIG_UPDATED" = "true" ]; then
         echo "Restarting the sshd service to get the updated configuration..."
         systemctl restart sshd
     else

--- a/scripts/linux/enable-ssh-password-authentication.sh
+++ b/scripts/linux/enable-ssh-password-authentication.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+# Stop the execution on errors.
+set -e
+
+SSH_CONFIG_FILE_PATH=/etc/ssh/sshd_config
+if [ -f "$SSH_CONFIG_FILE_PATH" ]; then
+    echo "Enabling password authentication for SSH connections."
+    SSHD_CONFIG_UPDATED=0
+    if grep -q "^PasswordAuthentication no" "$SSH_CONFIG_FILE_PATH"; then
+        echo "Password authentication for SSH connections is disabled. Enabling it..."
+        sed -i "s/^PasswordAuthentication no/PasswordAuthentication yes/" "$SSH_CONFIG_FILE_PATH"
+        SSHD_CONFIG_UPDATED=1
+    elif ! grep -q "^PasswordAuthentication"; then
+        echo "Enabling password authentication for SSH connections..."
+        sed -i -e "\$aPasswordAuthentication yes" "$SSH_CONFIG_FILE_PATH"
+        SSHD_CONFIG_UPDATED=1
+    fi
+
+    if [ "$SSHD_CONFIG_UPDATED" = 1 ]; then
+        echo "Restarting the sshd service to get the updated configuration..."
+        systemctl restart sshd
+    else
+        echo "The SSH daemon already accepts password authentication."
+    fi
+
+    unset SSHD_CONFIG_UPDATED
+else
+    echo "File $SSH_CONFIG_FILE_PATH not found."
+    exit 1
+fi
+
+# Re-enable the default behaviour, because we don't know if other scripts are
+# aware of this change.
+set +e


### PR DESCRIPTION
This PR adds a couple of checks when configuring sshd to enable password authentication and, most importantly, runs it not just for the libvirt provider, but for every provider, to ensure we have it enabled on all the boxes we use.

Close #136 