### PR TITLE
Set facts, debug info, remove ansible-provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,21 +212,13 @@ development environment dependencies.
 
 Ansible output is saved in the `/vagrant/ansible_output.txt`.
 
-For debbugging and development purposes, you can run a Vagrant provisioner called
-`ansible-debug` as follows:
-
-```shell
-vagrant provision --provision-with ansible-debug
-```
-
-With this provisioner, ansible will execute only the tasks tagged as follows:
+For debbugging and development purposes, you can add the verbosity flags in your
+`env.yaml` as follows:
 
 ```yaml
-  tags:
-    - ansible_debug
+conf:
+  additional_ansible_arguments: "-vv"
 ```
-
-An example task tagged with `ansible_debug` is included in [`ansible\kubernetes.yml`](ansible\kubernetes.yml)
 
 ### Automatic Ansible Inventory Creation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -534,12 +534,6 @@ Vagrant.configure("2") do |config|
             s.path = "scripts/linux/install-kubernetes.sh"
             s.args = ["--inventory", ansible_inventory_path, "--additional-ansible-arguments", additional_ansible_arguments, "--quick-setup" ]
           end
-
-          host.vm.provision "ansible-debug", type: "shell", run: "never" do |s|
-            s.path = "scripts/linux/install-kubernetes.sh"
-            s.args = ["--inventory", ansible_inventory_path, "--additional-ansible-arguments", additional_ansible_arguments, "--ansible-debug" ]
-          end
-
         end
         host.vm.provision "cleanup", type: "shell", run: "never" do |s|
           s.path = "scripts/linux/cleanup-k8s-and-cni.sh"

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -9,47 +9,53 @@
       listen:
         - systemd_read_configs
   post_tasks:
-    - name: ansible_debug_example_1
-        This task is only an example, it can be replaced by your own debug task
-        or other tasks with ansible_debug tag can be created
+    - name: Set ansible_ssh_connection_ip_v4_address fact
+      set_fact:
+        ansible_ssh_connection_ip_v4_address: >-
+          "{{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }}"
+    - name: Get the interface name for Ansible SSH connection interface
       become: true
       changed_when: false
       shell: |
-        set -e ; \
-        echo $0 ; \
-        whoami ; \
-        echo $PATH
-      register: ansible_debug_output
-      tags:
-        - ansible_debug
-    - name: ansible_debug_example_2
-        This task is only an example (see ansible_debug_example_1)
-      become: true
-      changed_when: false
-      debug:
-        var: ansible_debug_output
-      tags:
-        - ansible_debug
-    - name: >-
-        Get IP address corresponding to the interface with the specified
-        broadcast address
-      changed_when: false
-      shell: |
-        set -e -o pipefail; \
-        /usr/sbin/ip addr \
-        | grep {{ broadcast_address }} \
-        | awk -F'[ /]+' '{print $3}'
-      register: ip_addr_broadcast
+        set -e -o pipefail ; \
+        NODE_IP_V4={{ ansible_ssh_connection_ip_v4_address }} ; \
+        ip -o addr show | grep $NODE_IP_V4 | awk '{print $2}'
+      register: ansible_ssh_connection_interface_name_result
       tags:
         - quick_setup
-      when: "'kubernetes-masters' in group_names or 'kubernetes-minions' in group_names"
+    - name: Set facts
+      set_fact:
+        ansible_ssh_connection_interface_name: "{{ ansible_ssh_connection_interface_name_result.stdout }}"
+      tags:
+        - quick_setup
+    - name: Display all variables/facts known for {{ inventory_hostname }}
+      debug:
+        var: hostvars[inventory_hostname]
+        verbosity: 2
+    - name: Print debug information
+      changed_when: false
+      vars:
+        msg: |
+            Ansible distribution: {{ ansible_distribution }}
+            Ansible distribution version: {{ ansible_distribution_version }}
+            Ansible domain: {{ ansible_domain }}
+            Ansible FQDN: {{ ansible_fqdn }}
+            ansible hostname: {{ ansible_hostname }}
+            Ansible kernel: {{ ansible_kernel }}
+            Ansible user: {{ ansible_user }}
+            Ansible SSH connection IPv4 address: {{ ansible_ssh_connection_ip_v4_address }}
+            Ansible SSH connection interface name: {{ ansible_ssh_connection_interface_name }}
+            Inventory hostname: {{ inventory_hostname }}
+            PATH: {{ hostvars[inventory_hostname]['ansible_env']['PATH'] }}
+      debug:
+        msg: "{{ msg.split('\n') }}"
     - name: Initialize an IPv6 interface
       become: true
       shell: |
         set -e ; \
         /vagrant/scripts/linux/configure-ipv6-interface.sh \
         {{ ipv6_address }} \
-        {{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }} \
+        {{ ansible_ssh_connection_ip_v4_address }} \
         {{ subnet_mask_ipv6 }}
       when: ipv6_address is defined
     - name: Remove FQDN from 127.0.0.1
@@ -137,19 +143,9 @@
       when: inventory_hostname == kubernetes_master_1_ip
       tags:
         - quick_setup
-    - name: Get interface name for data interface
-      become: true
-      shell: |
-        set -e -o pipefail ; \
-        NODE_IP_V4={{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }} ; \
-        ip -o addr show scope global | grep $NODE_IP_V4 | awk '{print $2}'
-      register: node_ip_address
-      when: inventory_hostname == kubernetes_master_1_ip
-      tags:
-        - quick_setup
     - name: Define if_name_for_flannel
       set_fact:
-        if_name_for_flannel: "{{ node_ip_address.stdout }}"
+        if_name_for_flannel: "{{ ansible_ssh_connection_interface_name }}"
       when: inventory_hostname == kubernetes_master_1_ip
       tags:
         - quick_setup

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -13,6 +13,8 @@
       set_fact:
         ansible_ssh_connection_ip_v4_address: >-
           "{{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }}"
+      tags:
+        - quick_setup
     - name: Get the interface name for Ansible SSH connection interface
       become: true
       changed_when: false

--- a/ansible/templates/90-node-ip.conf.j2
+++ b/ansible/templates/90-node-ip.conf.j2
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS --node-ip={{ip_addr_broadcast.stdout}}"
+Environment="KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS --node-ip={{ ansible_ssh_connection_ip_v4_address }}"

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ! TEMP="$(getopt -o a:i:qm --long additional-ansible-arguments:,inventory:,quick-setup,ansible-debug \
+if ! TEMP="$(getopt -o a:i:q --long additional-ansible-arguments:,inventory:,quick-setup \
     -n 'install-kubernetes' -- "$@")"; then
     echo "Terminating..." >&2
     exit 1
@@ -26,11 +26,6 @@ while true; do
         shift
         break
         ;;
-    -m | --ansible-debug)
-        ansible_debug=enabled
-        shift
-        break
-        ;;
     --)
         shift
         break
@@ -41,10 +36,6 @@ done
 
 if [ "$quick_setup" = "enabled" ]; then
     additional_ansible_arguments="$additional_ansible_arguments --tags quick_setup"
-fi
-
-if [ "$ansible_debug" = "enabled" ]; then
-    additional_ansible_arguments="$additional_ansible_arguments --tags ansible_debug"
 fi
 
 echo "Ensure the Docker service is enabled and running"


### PR DESCRIPTION
This PR does the following:

1. Shorten and simplify the names of certain Ansible variables. For example, we now register some facts to avoid adding the `.stdout` suffix.
1. Register a fact pointing to the IPv4 address that Ansible uses to connect to the node (see the `ansible_ssh_connection_ip_v4_address` fact. This also simplifies the playbook because we avoid repeating ourselves in a couple of tasks.
1. Move the tasks that dynamically get information about the network interface name and address early on, so we can use those values earlier as well.
1. Remove the task to get the IP address of the interface by looking at the broadcast address, and use `ansible_ssh_connection_ip_v4_address` as the other tasks are doing.
1. Don't set the `scope global` selectors when looking for the interface name, so the task doesn't fail on VMs where we don't (currently) set a static IP, such as the base-box.
1. Implement a new approach to print debug output. We now have two new tasks:
   1. `Display all variables/facts known for {{ inventory_hostname }}`, that prints a long list of all the known facts for a given host. This runs only when Ansible verbosity is >= 2, to avoid cluttering the output.
   1. `Print debug information`, that prints a short list of the most important variables. This runs always, because the list is short. **LMK if you want to add/remove a variable**.
1. Remove the `ansible-debug` provisioner (Vagrantfile, install-kubernetes.sh and README) and related tags. This provisioner is not needed anymore, because the only thing we need to specify now is the Ansible verbosity, and we can use the `additional_ansible_arguments` configuration directive.

PS: this is work that will ease the implementation of #173 and #170 