### PR TITLE
Fix the mechanism to get the IPv4 address of the additional network interface

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -147,7 +147,7 @@ check_and_select_conf_options(settings["ansible"]["group_vars"]["all"],
                               "kubernetes_network_plugin",
                               ["no-cni-plugin", "weavenet", "calico", "flannel"],
                               ERR_NET_PLUGIN_CONF)
-@ui.info "Networking plugin : " + settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"]
+@ui.info "Networking plugin: " + settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"]
 # if calico, check that at least one and only one env_var and env_var_value is selected
 if settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"] == "calico"
   check_and_select_conf_options(settings["ansible"]["group_vars"]["all"]["calico_config"],
@@ -158,7 +158,7 @@ if settings["ansible"]["group_vars"]["all"]["kubernetes_network_plugin"] == "cal
                               "calico_env_var_value",
                               ["Always","CrossSubnet","Never"],
                               ERR_CALICO_ENV_VAR_VALUE_CONF)
-  @ui.info "Calico env variable: " + settings["ansible"]["group_vars"]["all"]["calico_config"]["calico_env_var"] +
+  @ui.info "Calico environment variable: " + settings["ansible"]["group_vars"]["all"]["calico_config"]["calico_env_var"] +
             "=" + settings["ansible"]["group_vars"]["all"]["calico_config"]["calico_env_var_value"]
 end
 
@@ -189,6 +189,9 @@ subnet_mask_ipv6 = settings["net"]["subnet_mask_ipv6"]
 
 kubeadm_token = "0y5van.5qxccw2ewiarl68v"
 kubernetes_master_1_ip = network_prefix + "10"
+kubernetes_minion_1_ip = network_prefix + "30"
+kubernetes_minion_2_ip = network_prefix + "31"
+kubernetes_minion_3_ip = network_prefix + "32"
 kubernetes_master_1_ipv6 = network_prefix_ipv6 + settings["net"]["master_ipv6_part"]
 kubernetes_minion_1_ipv6 = network_prefix_ipv6 + settings["net"]["minion_1_ipv6_part"]
 kubernetes_minion_2_ipv6 = network_prefix_ipv6 + settings["net"]["minion_2_ipv6_part"]
@@ -273,6 +276,7 @@ playground = {
     :subnet_mask => subnet_mask,
     :show_gui => false,
     :host_vars => {
+      "ipv4_address" => kubernetes_master_1_ip,
       "ipv6_address" => kubernetes_master_1_ipv6,
       assigned_hostname_key => kubernetes_master_1_vm_id
     }
@@ -283,12 +287,13 @@ playground = {
     :cpus => 1,
     :mac_address => "0800271F9D03",
     :mem => minion_mem,
-    :ip => network_prefix + "30",
+    :ip => kubernetes_minion_1_ip,
     :net_auto_config => true,
     :net_type => network_type_static_ip,
     :subnet_mask => subnet_mask,
     :show_gui => false,
     :host_vars => {
+      "ipv4_address" => kubernetes_minion_1_ip,
       "ipv6_address" => kubernetes_minion_1_ipv6,
       assigned_hostname_key => kubernetes_minion_1_vm_id
     }
@@ -299,12 +304,13 @@ playground = {
     :cpus => 1,
     :mac_address => "0800271F9D04",
     :mem => minion_mem,
-    :ip => network_prefix + "31",
+    :ip => kubernetes_minion_2_ip,
     :net_auto_config => true,
     :net_type => network_type_static_ip,
     :subnet_mask => subnet_mask,
     :show_gui => false,
     :host_vars => {
+      "ipv4_address" => kubernetes_minion_2_ip,
       "ipv6_address" => kubernetes_minion_2_ipv6,
       assigned_hostname_key => kubernetes_minion_2_vm_id
     }
@@ -315,12 +321,13 @@ playground = {
     :cpus => 1,
     :mac_address => "0800271F9D05",
     :mem => minion_mem,
-    :ip => network_prefix + "32",
+    :ip => kubernetes_minion_3_ip,
     :net_auto_config => true,
     :net_type => network_type_static_ip,
     :subnet_mask => subnet_mask,
     :show_gui => false,
     :host_vars => {
+      "ipv4_address" => kubernetes_minion_3_ip,
       "ipv6_address" => kubernetes_minion_3_ipv6,
       assigned_hostname_key => kubernetes_minion_3_vm_id
     }

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -24,19 +24,18 @@
       tags:
         - quick_setup
       when: ipv4_address is defined
+    - name: Set facts related to the additional network interface
+      set_fact:
+        additional_network_interface_name: "{{ additional_network_interface_name_result.stdout }}"
+      tags:
+        - quick_setup
+      when: ipv4_address is defined
     - name: Look up docker cgroup driver
       shell: "set -o pipefail && docker info | grep 'Cgroup Driver' | awk -F': ' '{ print $2; }'"
       register: docker_cgroup_driver_result
       changed_when: false
       tags:
         - quick_setup
-    - name: Set facts related to the additional network interface
-      set_fact:
-        additional_network_interface_name: "{{ additional_network_interface_name_result.stdout }}"
-        if_name_for_flannel: "{{ additional_network_interface_name }}"
-      tags:
-        - quick_setup
-      when: ipv4_address is defined
     - name: Set additional facts
       set_fact:
         docker_cgroup_driver: "{{ docker_cgroup_driver_result.stdout }}"
@@ -80,7 +79,6 @@
             Ansible user: {{ ansible_user }}
             Cluster IP CIDR: {{ cluster_ip_cidr }}
             Docker cgroup driver: {{ docker_cgroup_driver }}
-            Interface name for flannel: {{ if_name_for_flannel | default('NOT DEFINED') }}
             Inventory hostname: {{ inventory_hostname }}
             IP address: {{ ipv4_address | default('NOT DEFINED') }}
             IPv6 address: {{ ipv6_address | default('NOT DEFINED') }}
@@ -180,7 +178,7 @@
         mode: 0755
         owner: root
         src: templates/kube-flannel-config.yaml.j2
-      when: inventory_hostname == kubernetes_master_1_hostname and if_name_for_flannel is defined
+      when: inventory_hostname == kubernetes_master_1_hostname and additional_network_interface_name is defined
       tags:
         - initialize_kubernetes_cluster
         - quick_setup

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -88,7 +88,6 @@
         set -e ; \
         /vagrant/scripts/linux/configure-ipv6-interface.sh \
         {{ ipv6_address }} \
-        {{ ansible_ssh_connection_ip_v4_address }} \
         {{ subnet_mask_ipv6 }} \
         {{ ansible_ssh_connection_interface_name }} \
         {{ ansible_ssh_connection_nm_connection_name }}

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -14,47 +14,52 @@
       debug:
         var: hostvars[inventory_hostname]
         verbosity: 2
-    - name: Set ansible_ssh_connection_ip_v4_address fact
-      set_fact:
-        ansible_ssh_connection_ip_v4_address: >-
-          {{ hostvars[inventory_hostname]['ansible_env'].SSH_CONNECTION.split(' ')[2] }}
-      tags:
-        - quick_setup
-    - name: Get the interface name for Ansible SSH connection interface
+    - name: Get the interface name for the additional network interface
       become: true
       changed_when: false
       shell: |
         set -e -o pipefail ; \
-        ip -o addr show | grep {{ ansible_ssh_connection_ip_v4_address }} | awk '{print $2}'
-      register: ansible_ssh_connection_interface_name_result
+        ip -o addr show | grep {{ ipv4_address }} | awk '{print $2}'
+      register: additional_network_interface_name_result
       tags:
         - quick_setup
+      when: ipv4_address is defined
     - name: Look up docker cgroup driver
       shell: "set -o pipefail && docker info | grep 'Cgroup Driver' | awk -F': ' '{ print $2; }'"
       register: docker_cgroup_driver_result
       changed_when: false
       tags:
         - quick_setup
-    - name: Set facts
+    - name: Set facts related to the additional network interface
       set_fact:
-        ansible_ssh_connection_interface_name: "{{ ansible_ssh_connection_interface_name_result.stdout }}"
+        additional_network_interface_name: "{{ additional_network_interface_name_result.stdout }}"
+        if_name_for_flannel: "{{ additional_network_interface_name }}"
+      tags:
+        - quick_setup
+      when: ipv4_address is defined
+    - name: Set additional facts
+      set_fact:
         docker_cgroup_driver: "{{ docker_cgroup_driver_result.stdout }}"
       tags:
         - quick_setup
-    - name: Get the NetworkManager connection UUID for the {{ ansible_ssh_connection_interface_name }} connection
+    - name: |
+        Get the NetworkManager connection UUID for the {{ additional_network_interface_name | default('NOT DEFINED') }}
+        connection
       become: true
       changed_when: false
       shell: |
         set -e -o pipefail ; \
-        nmcli -g UUID,DEVICE con show | grep {{ ansible_ssh_connection_interface_name }} | awk -F ":" '{print $1}'
-      register: ansible_ssh_connection_nm_connection_name_result
+        nmcli -g UUID,DEVICE con show | grep {{ additional_network_interface_name }} | awk -F ":" '{print $1}'
+      register: additional_network_interface_nm_conn_name_result
       tags:
         - quick_setup
-    - name: Set facts
+      when: ipv4_address is defined
+    - name: Set more facts related to the additional network interface
       set_fact:
-        ansible_ssh_connection_nm_connection_name: "{{ ansible_ssh_connection_nm_connection_name_result.stdout }}"
+        additional_network_interface_nm_connection_name: "{{ additional_network_interface_nm_conn_name_result.stdout }}"
       tags:
         - quick_setup
+      when: ipv4_address is defined and additional_network_interface_nm_conn_name_result is defined
     - name: Display all variables/facts known for {{ inventory_hostname }} after setting facts
       debug:
         var: hostvars[inventory_hostname]
@@ -63,6 +68,9 @@
       changed_when: false
       vars:
         msg: |
+            Additional network interface IPv4 address: {{ ipv4_address | default('NOT DEFINED') }}
+            Additional network interface name: {{ additional_network_interface_name | default('NOT DEFINED') }}
+            Additional network NM UUID: {{ additional_network_interface_nm_connection_name | default('NOT DEFINED') }}
             Ansible distribution: {{ ansible_distribution }}
             Ansible distribution version: {{ ansible_distribution_version }}
             Ansible domain: {{ ansible_domain }}
@@ -70,12 +78,11 @@
             ansible hostname: {{ ansible_hostname }}
             Ansible kernel: {{ ansible_kernel }}
             Ansible user: {{ ansible_user }}
-            Ansible SSH connection IPv4 address: {{ ansible_ssh_connection_ip_v4_address }}
-            Ansible SSH connection interface name: {{ ansible_ssh_connection_interface_name }}
-            Ansible SSH connection Networkmanager UUID: {{ ansible_ssh_connection_nm_connection_name }}
             Cluster IP CIDR: {{ cluster_ip_cidr }}
             Docker cgroup driver: {{ docker_cgroup_driver }}
+            Interface name for flannel: {{ if_name_for_flannel | default('NOT DEFINED') }}
             Inventory hostname: {{ inventory_hostname }}
+            IP address: {{ ipv4_address | default('NOT DEFINED') }}
             IPv6 address: {{ ipv6_address | default('NOT DEFINED') }}
             Kubeadm token: {{ kubeadm_token }}
             Kubernetes master 1 hostname: {{ kubernetes_master_1_hostname }}
@@ -86,15 +93,15 @@
             Subnet mask IPv6: {{ subnet_mask_ipv6 }}
       debug:
         msg: "{{ msg.split('\n') }}"
-    - name: Add an IPv6 address to {{ ansible_ssh_connection_interface_name }}
+    - name: Add an IPv6 address to {{ additional_network_interface_name }}
       become: true
       shell: |
         set -e ; \
         /vagrant/scripts/linux/configure-ipv6-interface.sh \
         {{ ipv6_address }} \
         {{ subnet_mask_ipv6 }} \
-        {{ ansible_ssh_connection_interface_name }} \
-        {{ ansible_ssh_connection_nm_connection_name }}
+        {{ additional_network_interface_name }} \
+        {{ additional_network_interface_nm_connection_name }}
       when: ipv6_address is defined
     - name: Remove FQDN from 127.0.0.1
       become: true
@@ -164,12 +171,6 @@
       when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - quick_setup
-    - name: Define if_name_for_flannel
-      set_fact:
-        if_name_for_flannel: "{{ ansible_ssh_connection_interface_name }}"
-      when: inventory_hostname == kubernetes_master_1_hostname
-      tags:
-        - quick_setup
     - name: Generate Flannel configuration file
       become: true
       template:
@@ -179,7 +180,7 @@
         mode: 0755
         owner: root
         src: templates/kube-flannel-config.yaml.j2
-      when: inventory_hostname == kubernetes_master_1_hostname
+      when: inventory_hostname == kubernetes_master_1_hostname and if_name_for_flannel is defined
       tags:
         - initialize_kubernetes_cluster
         - quick_setup

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -137,7 +137,7 @@
         mode: 0755
         owner: root
         src: templates/kubeadm-config.yaml.j2
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - quick_setup
     - name: Generate weavenet configuration file
@@ -149,7 +149,7 @@
         mode: 0755
         owner: root
         src: templates/weavenet-config.yaml.j2
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - quick_setup
     - name: Generate Calico configuration file
@@ -161,13 +161,13 @@
         mode: 0755
         owner: root
         src: templates/calico-config.yaml.j2
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - quick_setup
     - name: Define if_name_for_flannel
       set_fact:
         if_name_for_flannel: "{{ ansible_ssh_connection_interface_name }}"
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - quick_setup
     - name: Generate Flannel configuration file
@@ -179,7 +179,7 @@
         mode: 0755
         owner: root
         src: templates/kube-flannel-config.yaml.j2
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - initialize_kubernetes_cluster
         - quick_setup
@@ -192,7 +192,7 @@
         {{ kubernetes_network_plugin }}
       args:
         creates: /home/vagrant/.kube/config
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
       tags:
         - initialize_kubernetes_cluster
         - quick_setup
@@ -201,12 +201,12 @@
         dest: /home/vagrant/.bashrc
         line: "source <(kubectl completion bash)"
         owner: vagrant
-      when: ansible_ssh_connection_ip_v4_address == kubernetes_master_1_ip
+      when: inventory_hostname == kubernetes_master_1_hostname
     - name: Initialize Kubernetes cluster (workers)
       become: true
       shell: |
         /vagrant/scripts/linux/bootstrap-kubernetes-{{ kubernetes_classifier }}.sh \
-        {{ kubernetes_master_1_ip }} \
+        {{ kubernetes_master_1_hostname }} \
         {{ kubeadm_token }} \
         {{ cluster_ip_cidr }} \
         {{ kubernetes_network_plugin }}

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -10,6 +10,10 @@
       listen:
         - systemd_read_configs
   post_tasks:
+    - name: Display all variables/facts known for {{ inventory_hostname }} after applying roles
+      debug:
+        var: hostvars[inventory_hostname]
+        verbosity: 2
     - name: Set ansible_ssh_connection_ip_v4_address fact
       set_fact:
         ansible_ssh_connection_ip_v4_address: >-
@@ -51,7 +55,7 @@
         ansible_ssh_connection_nm_connection_name: "{{ ansible_ssh_connection_nm_connection_name_result.stdout }}"
       tags:
         - quick_setup
-    - name: Display all variables/facts known for {{ inventory_hostname }}
+    - name: Display all variables/facts known for {{ inventory_hostname }} after setting facts
       debug:
         var: hostvars[inventory_hostname]
         verbosity: 2

--- a/ansible/roles/kubernetes/tasks/preflight-checks.yml
+++ b/ansible/roles/kubernetes/tasks/preflight-checks.yml
@@ -1,5 +1,5 @@
 ---
-- name: Refresh facts to evaluate the fresh information
+- name: Refresh facts to evaluate fresh information
   setup:
 
 - name: Stop if swap enabled

--- a/ansible/templates/90-node-ip.conf.j2
+++ b/ansible/templates/90-node-ip.conf.j2
@@ -1,2 +1,2 @@
 [Service]
-Environment="KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS --node-ip={{ ansible_ssh_connection_ip_v4_address }}"
+Environment="KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS --node-ip={{ ipv4_address }}"

--- a/ansible/templates/kube-flannel-config.yaml.j2
+++ b/ansible/templates/kube-flannel-config.yaml.j2
@@ -189,7 +189,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
-        - --iface={{if_name_for_flannel}}
+        - --iface={{additional_network_interface_name}}
         resources:
           requests:
             cpu: "100m"
@@ -284,7 +284,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
-        - --iface={{if_name_for_flannel}}
+        - --iface={{additional_network_interface_name}}
         resources:
           requests:
             cpu: "100m"
@@ -379,7 +379,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
-        - --iface={{if_name_for_flannel}}
+        - --iface={{additional_network_interface_name}}
         resources:
           requests:
             cpu: "100m"
@@ -474,7 +474,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
-        - --iface={{if_name_for_flannel}}
+        - --iface={{additional_network_interface_name}}
         resources:
           requests:
             cpu: "100m"
@@ -569,7 +569,7 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
-        - --iface={{if_name_for_flannel}}
+        - --iface={{additional_network_interface_name}}
         resources:
           requests:
             cpu: "100m"

--- a/scripts/linux/configure-ipv6-interface.sh
+++ b/scripts/linux/configure-ipv6-interface.sh
@@ -3,12 +3,9 @@
 echo "Configuring the IPv6 interface"
 
 IPV6_ADDRESS="$1"
-CURRENT_IPV4_ADDRESS="$2"
-IPV6_NETMASK="$3"
-DEVICE="$4"
-UUID="$5"
-
-echo "Current IPv4 address $CURRENT_IPV4_ADDRESS assigned to $DEVICE"
+IPV6_NETMASK="$2"
+DEVICE="$3"
+UUID="$4"
 
 echo "Current NetworkManager UUID $UUID assigned to $DEVICE"
 

--- a/scripts/linux/install-docker.sh
+++ b/scripts/linux/install-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if ! TEMP="$(getopt -o vdm: --long user: -n 'install-docker' -- "$@")"; then
     echo "Terminating..." >&2
     exit 1


### PR DESCRIPTION
This PR does the following:

1. Adds the `ipv4_address` variable to the `host_vars` for each host that has a fixed IP address.
1. Uses the `ipv4_address` instead of the `ansible_ssh_connection_ipv4_address`.
1. Removes the tasks that set `ansible_ssh_connection_ipv4_address`.
1. Skips tasks that depend on `ipv4_address`, when `ipv4_address` is not defined.
1. Adds a task that prints the known facts after applying the roles, and before setting other facts. The required verbosity is set to 2.
1. Removes an unneeded parameter from `configure-ipv6-interface.sh`.
1. Uses `inventory_hostname` and `kubernetes_master_1_hostname` when checking conditions, instead of `ansible_ssh_connection_ip_v4_address` and `kubernetes_master_1_ip`.


Close #216 