### PR TITLE
Update to Vagrant 2.2.9 and add version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@
 dist: bionic
 env:
   global:
-    - VAGRANT_VERSION="2.2.7"
+    # When changing this, ensure that the Vagrantfile is updated as well
+    - VAGRANT_VERSION="2.2.9"
     - BASE_BOX_VAGRANT_VM_ID="base-box-builder.k8s-play.local"
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,7 @@ jobs:
         - gem query --local
         - bundle list
         - tree .
+        - vagrant version
         - vagrant validate
         - vagrant status
         - vagrant box list -i

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This project is a playground to play with Kubernetes.
 
 ### Runtime
 
-1. Vagrant >= 2.2.7
+1. Vagrant. For the exact version, look the `Vagrant.require_version` constraint
+    in the [Vagrantfile](Vagrantfile).
 
 #### Vagrant providers
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ require 'yaml'
 require 'ipaddr'
 
 # When changing this, ensure that the CI environment is updated as well
-Vagrant.require_version "== 2.2.9"
+Vagrant.require_version "= 2.2.9"
 
 @ui = Vagrant::UI::Colored.new
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,9 @@
 require 'yaml'
 require 'ipaddr'
 
+# When changing this, ensure that the CI environment is updated as well
+Vagrant.require_version "== 2.2.9"
+
 @ui = Vagrant::UI::Colored.new
 
 # Definition of constants


### PR DESCRIPTION
This PR:

1. Updates Vagrant to 2.2.9 the CI environment.
1. Enforces that we're using Vagrant 2.2.9.
1. Removes specific Vagrant version information, asking to look in the Vagrantfile instead.

Close #223 