### PR TITLE
Don't install the deprecated libvirt-bin package

### DIFF
--- a/scripts/linux/ci/install-libvirt.sh
+++ b/scripts/linux/ci/install-libvirt.sh
@@ -13,7 +13,6 @@ apt-get install -y --no-install-recommends \
     libguestfs-tools \
     libvirt-clients \
     libvirt-daemon-system \
-    libvirt-bin \
     libvirt-dev \
     libxml2-dev \
     libxslt1-dev \


### PR DESCRIPTION
[The `libvirt-bin` package has been split in two parts: `libvirt-daemon-system` and `libvirt-clients`](https://lists.debian.org/debian-user/2016/11/msg00518.html).

Removing it, because it's deprecated and not all Debian distributions have it available.